### PR TITLE
extend from \Slim\View, add default path

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -17,7 +17,7 @@ namespace Slim\Views;
  *
  * @link http://twig.sensiolabs.org/
  */
-class Twig implements \Pimple\ServiceProviderInterface
+class Twig extends \Slim\View implements \Pimple\ServiceProviderInterface
 {
     /**
      * Twig loader
@@ -50,8 +50,9 @@ class Twig implements \Pimple\ServiceProviderInterface
      * @param string $path     Path to templates directory
      * @param array  $settings Twig environment settings
      */
-    public function __construct($path, $settings = [])
+    public function __construct($path = './', $settings = [])
     {
+        parent::__construct();
         $this->loader = new \Twig_Loader_Filesystem($path);
         $this->environment = new \Twig_Environment($this->loader, $settings);
     }


### PR DESCRIPTION
Hi,
I had a trouble while installation. I tried to solve it, maybe my decision helps.
For use with last version of Slim: extend class from \Slim\View and add default path.

My example of including:
```
$app->view(new \Slim\Views\Twig(APP_PATH . '/views', [
    'cache' => realpath(APP_PATH . '/../data/cache')
]));
```