### PR TITLE
Fix Service Provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Requires Slim Framework 3 and PHP 5.4.0 or newer.
 // Create Slim app
 $app = new \Slim\App();
 
+// Fetch DI Container
+$container = $app->getContainer();
+
 // Register Twig View helper
-$app->register(new \Slim\Views\Twig('path/to/templates', [
+$container->register(new \Slim\Views\Twig('path/to/templates', [
     'cache' => 'path/to/cache'
 ]));
 


### PR DESCRIPTION
\Slim\App is no longer a instance of \Pimple\Container. This affects registration of Pimple Service Providers. See issue https://github.com/slimphp/Slim/issues/1250.