### PR TITLE
Fix named route example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $container->register(new \Slim\Views\Twig('path/to/templates', [
 
 // Define named route
 $app->get('/hello/{name}', function ($request, $response, $args) {
-    return $this['view']->render($response, 'profile.html', [
+    return $this->getContainer()->get('view')->render($response, 'profile.html', [
         'name' => $args['name']
     ]);
 })->setName('profile');

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $container->register(new \Slim\Views\Twig('path/to/templates', [
 
 // Define named route
 $app->get('/hello/{name}', function ($request, $response, $args) {
-    return $this->getContainer()->get('view')->render($response, 'profile.html', [
+    return $this->view->render($response, 'profile.html', [
         'name' => $args['name']
     ]);
 })->setName('profile');


### PR DESCRIPTION
$this['view'] results (with the current Twig development branch) in

```Fatal error: Cannot use object of type Slim\App as array```

This fixes that.