### PR TITLE
Update to include ArrayAccess

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
  *
  * @link http://twig.sensiolabs.org/
  */
-class Twig implements \Pimple\ServiceProviderInterface
+class Twig implements \ArrayAccess, \Pimple\ServiceProviderInterface
 {
     /**
      * Twig loader


### PR DESCRIPTION
offsetSet, offsetExists, offsetUnset, offsetGet are all defined, but \ArrayAccess was missing from the "implements" of the class.

With \ArrayAccess I can set parameters in my __construct: $this->view['BaseUrl'] = '/public/;