### PR TITLE
Implement addExtension to proxy through to the environment.

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -80,6 +80,17 @@ class Twig implements \ArrayAccess, \Pimple\ServiceProviderInterface
      *******************************************************************************/
 
     /**
+     * Proxy method to add an extension to the Twig environment
+     *
+     * @param array|object $extension A single extension instance or an array of instances
+     */
+    public function addExtension(\Twig_ExtensionInterface $extension)
+    {
+        $this->environment->addExtension($extension);
+    }
+
+
+    /**
      * Fetch rendered template
      *
      * @param  string $template Template pathname relative to templates directory


### PR DESCRIPTION
This is a simple helper method that makes using this component just a little easier.

Usage is now:

```php
$view->addExtension(new Twig_Extension_Debug());
```

It was:
```php
$environment = $view->getEnvironment();
$environment->addExtension(new Twig_Extension_Debug());
```