### PR TITLE
Implemented correct DI for baseUrl

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -16,7 +16,7 @@ class TwigExtension extends \Twig_Extension
     private $router;
 
     /**
-     * @var \Slim\Http\Uri
+     * @var string|\Slim\Http\Uri
      */
     private $uri;
 
@@ -46,6 +46,9 @@ class TwigExtension extends \Twig_Extension
 
     public function baseUrl()
     {
+        if (is_string($this->uri)) {
+            return $this->uri;
+        }
         if (method_exists($this->uri, 'getBaseUrl')) {
             return $this->uri->getBaseUrl();
         }


### PR DESCRIPTION
There is no need to path full `\Slim\Http\Uri` object inside extension, as far as you need only `baseUrl`. So, instead you should inject **ONLY** what you need. But, for backward compatibility I saved possibility to pass whole `\Slim\Http\Uri`object.

So, correct way to create Twig extension now will look like this:

```
$view->addExtension(new Slim\Views\TwigExtension(
    $container->get('router'),
    $container->get('request')->getUri()->getBaseUrl()
));
```

OR:

```
$view->addExtension(new Slim\Views\TwigExtension(
    $container->get('router'),
    $container->get('settings')['baseUrl']
));
```

OR

```
$view->addExtension(new Slim\Views\TwigExtension(
    $container->get('router'),
    'http://mywebsite.com'
));
```