### PR TITLE
Fixed return type hint to match Twig_Environment class

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -132,7 +132,7 @@ class Twig implements \ArrayAccess, \Pimple\ServiceProviderInterface
     /**
      * Return Twig environment
      *
-     * @return \Twig_EnvironmentInterface
+     * @return \Twig_Environment
      */
     public function getEnvironment()
     {


### PR DESCRIPTION
Original annotation referenced non-existent Twig interface. Changed to reference correct class, so IDEs can autocomplete.