### PR TITLE
Provide the ability to use addFilter with Twig

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -73,6 +73,16 @@ class Twig implements \ArrayAccess
         $this->environment->addExtension($extension);
     }
 
+    /**
+     * Registers a Filter.
+     *
+     * @param string|Twig_SimpleFilter               $name   The filter name or a Twig_SimpleFilter instance
+     * @param Twig_FilterInterface|Twig_SimpleFilter $filter A Twig_FilterInterface instance or a Twig_SimpleFilter instance
+     */
+    public function addFilter($name, $filter = null)
+    {
+        $this->environment->addFilter($name, $filter);
+    }
 
     /**
      * Fetch rendered template


### PR DESCRIPTION
Adding this function allows users to add filters they created within the Pimple container of their apps. It can be a SimpleFilter or FilterInterface.

This is a pretty basic function of Twig and it's pretty nice to have it provided by Slim's Twig-View as well.