### PR TITLE
Remove script name for base url()

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -51,6 +51,7 @@ class TwigExtension extends \Twig_Extension
         }
         if (method_exists($this->uri, 'getBaseUrl')) {
             $url = $this->uri->getBaseUrl();
+            // remove script name from URL for view that use base_url so that css and js will show correctly
             return preg_replace('/\/\w+\.php$/i', '', rtrim($url,'/'));            
         }
     }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -50,7 +50,8 @@ class TwigExtension extends \Twig_Extension
             return $this->uri;
         }
         if (method_exists($this->uri, 'getBaseUrl')) {
-            return $this->uri->getBaseUrl();
+            $url = $this->uri->getBaseUrl();
+            return preg_replace('/\/\w+\.php$/i', '', rtrim($url,'/'));            
         }
     }
 }


### PR DESCRIPTION
I have spent many hours on this issue and tries various way and the dependencies.php does not fix base_url() for twig-View, it must be done in baseUrl of TwigExtension for it to work correctly in all cases that I test and the good thing is the URL will still retain the script name, just the css and js that get the correct url to show css and jv.

Please review the pull request to see if this can be used.

Thanks
