### PR TITLE
Fetch Template from string

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -93,6 +93,21 @@ class Twig implements \ArrayAccess
     }
 
     /**
+     * Fetch rendered string
+     *
+     * @param  string $string String
+     * @param  array  $data   Associative array of template variables
+     *
+     * @return string
+     */
+    public function fetchFromString($string ="", $data = [])
+    {
+        $data = array_merge($this->defaultVariables, $data);
+
+        return $this->environment->createTemplate($string)->render($data);
+    }
+
+    /**
      * Output rendered template
      *
      * @param ResponseInterface $response

--- a/tests/TwigTest.php
+++ b/tests/TwigTest.php
@@ -25,6 +25,17 @@ class TwigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("<p>Hi, my name is Josh.</p>\n", $output);
     }
 
+    public function testFetchFromString()
+    {
+        $view = new Twig(dirname(__FILE__) . '/templates');
+
+        $output = $view->fetchFromString("<p>Hi, my name is {{ name }}.</p>", [
+            'name' => 'Josh'
+        ]);
+
+        $this->assertEquals("<p>Hi, my name is Josh.</p>", $output);
+    }
+
     public function testSingleNamespaceAndMultipleDirectories()
     {
         $weekday = (new \DateTimeImmutable('2016-03-08'))->format('l');


### PR DESCRIPTION
Add a method to get a rendered template from a string instead of a template file. This way you can create templates from, i.e, databases.

http://twig.sensiolabs.org/doc/recipes.html#loading-a-template-from-a-string