### PR TITLE
Adding the "addFunction" proxy method to the Twig base class

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -78,6 +78,16 @@ class Twig implements \ArrayAccess
 
 
     /**
+     * Proxy method to add a function to the Twig environment
+     *
+     * @param \Twig_SimpleFunction $function A single function instance
+     */
+    public function addFunction(\Twig_SimpleFunction $function)
+    {
+        $this->environment->addFunction($function);
+    }
+
+    /**
      * Fetch rendered template
      *
      * @param  string $template Template pathname relative to templates directory


### PR DESCRIPTION
There's already an `addExtension` in the `Twig` class so this PR add the complementary `addFunction` method.