### PR TITLE
Type-hint $data param in Twig::render()

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -100,7 +100,7 @@ class Twig implements \ArrayAccess
      * @param  array $data Associative array of template variables
      * @return ResponseInterface
      */
-    public function render(ResponseInterface $response, $template, $data = [])
+    public function render(ResponseInterface $response, $template, array $data = [])
     {
          $response->getBody()->write($this->fetch($template, $data));
 


### PR DESCRIPTION
This pull request adds the `array` type hint to the `$data` parameter for `Twig::render`.  This parameter is ultimately passed to [Twig_TemplateInterface::render](https://github.com/twigphp/Twig/blob/1.x/lib/Twig/TemplateInterface.php#L32) as the `$context` parameter, which is also type hinted as an array.

