### PR TITLE
Is current path segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This component exposes a custom `path_for()` function to your Twig templates. Yo
     {% block body %}
     <h1>User List</h1>
     <ul>
-        <li><a href="{{ path_for('profile', { 'name': 'josh' }) }}">Josh</a></li>
+        <li><a href="{{ path_for('profile', { 'name': 'josh' }) }}" {% if is_current_path('profle', { 'name': 'josh' }) %}class="active"{% endif %}>Josh</a></li>
+        <li><a href="{{ path_for('profile', { 'name': 'andrew' }) }}">Andrew</a></li>
     </ul>
     {% endblock %}
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -55,9 +55,9 @@ class TwigExtension extends \Twig_Extension
         }
     }
 
-    public function isCurrentPath($name)
+    public function isCurrentPath($name, $data = [])
     {
-        return $this->router->pathFor($name) === $this->uri->getPath();
+        return $this->router->pathFor($name, $data) === $this->uri->getPath();
     }
 
     /**


### PR DESCRIPTION
I noticed that is_current_path failed if a twig route had variable url segments, so I allowed them to be passed through the twig template function so they could be evaluated by isCurrentPath.

Updated the README documentation to show a is_current_path example, as it was undocumented before.