### PR TITLE
Added fetchBlock method + test + template

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -89,6 +89,22 @@ class Twig implements \ArrayAccess
     }
 
     /**
+     * Fetch rendered block
+     *
+     * @param  string $template Template pathname relative to templates directory
+     * @param  string $block    Name of the block within the template
+     * @param  array  $data     Associative array of template variables
+     *
+     * @return string
+     */
+    public function fetchBlock($template, $block, $data = [])
+    {
+        $data = array_merge($this->defaultVariables, $data);
+
+        return $this->environment->loadTemplate($template)->renderBlock($block, $data);
+    }
+
+    /**
      * Fetch rendered string
      *
      * @param  string $string String

--- a/tests/TwigTest.php
+++ b/tests/TwigTest.php
@@ -36,6 +36,22 @@ class TwigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("<p>Hi, my name is Josh.</p>", $output);
     }
 
+    public function testFetchBlock()
+    {
+        $view = new Twig(dirname(__FILE__) . '/templates');
+
+        $outputOne = $view->fetchBlock('block_example.html', 'first', [
+            'name' => 'Josh'
+        ]);
+
+        $outputTwo = $view->fetchBlock('block_example.html', 'second', [
+            'name' => 'Peter'
+        ]);
+
+        $this->assertEquals("<p>Hi, my name is Josh.</p>", $outputOne);
+        $this->assertEquals("<p>My name is not Peter.</p>", $outputTwo);
+    }
+
     public function testSingleNamespaceAndMultipleDirectories()
     {
         $weekday = (new \DateTimeImmutable('2016-03-08'))->format('l');

--- a/tests/templates/block_example.html
+++ b/tests/templates/block_example.html
@@ -1,0 +1,2 @@
+{% block first %}<p>Hi, my name is {{name}}.</p>{% endblock %}
+{% block second %}<p>My name is not {{name}}.</p>{% endblock %}


### PR DESCRIPTION
Added fetchBlock method for use in situations where you want to keep several template blocks together in one file. 

For example an email template where you would have blocks for subject, HTML, text etc. in one file.