### PR TITLE
Add dist:trusty to fix HHVM build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6


### PR DESCRIPTION
Adding dist:trusty should fix the travis build error in the current pull requests. 

Error:
`HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with dist: trusty.`