### PR TITLE
Avoid calling "loadTemplate()" which is marked as internal

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -85,7 +85,7 @@ class Twig implements \ArrayAccess
     {
         $data = array_merge($this->defaultVariables, $data);
 
-        return $this->environment->loadTemplate($template)->render($data);
+        return $this->environment->render($template, $data);
     }
 
     /**


### PR DESCRIPTION
Twig_Environment::loadTemplate() is marked as internal since Twig 1.28.0.
This change proxies the call directly to Twig_Environment::render().