### PR TITLE
Only URI class

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ $container['view'] = function ($c) {
     ]);
     
     // Instantiate and add Slim specific extension
-    $basePath = rtrim(str_ireplace('index.php', '', $c['request']->getUri()->getBasePath()), '/');
-    $view->addExtension(new \Slim\Views\TwigExtension($c['router'], $basePath));
+    $view->addExtension(new \Slim\Views\TwigExtension($c['router'], $c['request']->getUri()));
+    // if we need set some base path use withBasePath() method from URI class
+    // $view->addExtension(new \Slim\Views\TwigExtension($c['router'], $c['request']->getUri()->withBasePath('/test')));
 
     return $view;
 };

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -23,11 +23,6 @@ class TwigExtension extends \Twig_Extension
      */
     private $uri;
 
-    /**
-     * @var string Base url from URI instance
-     */
-    protected $baseUrl;
-
     public function __construct(Router $router, Uri $uri)
     {
         $this->router = $router;
@@ -44,27 +39,43 @@ class TwigExtension extends \Twig_Extension
         return [
             new \Twig_SimpleFunction('path_for', array($this, 'pathFor')),
             new \Twig_SimpleFunction('base_url', array($this, 'baseUrl')),
+            new \Twig_SimpleFunction('base_path', array($this, 'basePath')),
             new \Twig_SimpleFunction('is_current_path', array($this, 'isCurrentPath')),
         ];
     }
 
+    /**
+     * Get path for named route
+     *
+     * @param $name Name of route
+     * @param array $data ?
+     * @param array $queryParams ?
+     * @param string $appName ?
+     * @return string Path for named routes\
+     */
     public function pathFor($name, $data = [], $queryParams = [], $appName = 'default')
     {
         return $this->router->pathFor($name, $data, $queryParams);
     }
 
     /**
-     * Get base URL
+     * Get base URL i.e. http://www.slimframework.com/
      *
      * @return string
      */
     public function baseUrl()
     {
-        if(isset($this->baseUrl)) {
-            return $this->filterBaseUrl($this->baseUrl);
-        } else {
-            return $this->filterBaseUrl($this->uri->getBaseUrl());
-        }
+        return $this->indexClean($this->uri->getBaseUrl());
+    }
+
+    /**
+     * Get base_path i.e. working directory of Slim index.php
+     *
+     * @return string
+     */
+    public function basePath()
+    {
+        return $this->indexClean($this->uri->getBasePath());
     }
 
     /**
@@ -80,24 +91,14 @@ class TwigExtension extends \Twig_Extension
     }
 
     /**
-     * Set the base url
+     * Remove index.php from base_url | base_path
      *
-     * @param Slim\Http\Uri $baseUrl
-     * @return void
+     * @param string $base Getting base_url | base_path
+     * @return string Filtered base_url | base_path
      */
-    public function setBaseUrl($baseUrl)
+    public function indexClean($base)
     {
-        $this->baseUrl = $baseUrl;
-    }
-
-    /**
-     * Remove index.php from baseUrl
-     *
-     * @param string $baseUrl Getting base URL
-     * @return string Filtered base url
-     */
-    public function filterBaseUrl($baseUrl)
-    {
-        return rtrim(str_ireplace('index.php', '', $baseUrl), '/');
+        $replaces = ['index.php', 'index.php?'];
+        return rtrim(str_ireplace($replaces, '', $base), '/');
     }
 }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -8,19 +8,27 @@
  */
 namespace Slim\Views;
 
+use \Slim\Router;
+use \Slim\Http\Uri;
+
 class TwigExtension extends \Twig_Extension
 {
     /**
-     * @var \Slim\Interfaces\RouterInterface
+     * @var \Slim\Router
      */
     private $router;
 
     /**
-     * @var string|\Slim\Http\Uri
+     * @var \Slim\Http\Uri
      */
     private $uri;
 
-    public function __construct($router, $uri)
+    /**
+     * @var string Base url from URI instance
+     */
+    protected $baseUrl;
+
+    public function __construct(Router $router, Uri $uri)
     {
         $this->router = $router;
         $this->uri = $uri;
@@ -45,16 +53,27 @@ class TwigExtension extends \Twig_Extension
         return $this->router->pathFor($name, $data, $queryParams);
     }
 
+    /**
+     * Get base URL
+     *
+     * @return string
+     */
     public function baseUrl()
     {
-        if (is_string($this->uri)) {
-            return $this->uri;
-        }
-        if (method_exists($this->uri, 'getBaseUrl')) {
-            return $this->uri->getBaseUrl();
+        if(isset($this->baseUrl)) {
+            return $this->filterBaseUrl($this->baseUrl);
+        } else {
+            return $this->filterBaseUrl($this->uri->getBaseUrl());
         }
     }
 
+    /**
+     * Check if current route is current path
+     *
+     * @param $name Current route
+     * @param array $data
+     * @return bool
+     */
     public function isCurrentPath($name, $data = [])
     {
         return $this->router->pathFor($name, $data) === $this->uri->getPath();
@@ -63,11 +82,22 @@ class TwigExtension extends \Twig_Extension
     /**
      * Set the base url
      *
-     * @param string|Slim\Http\Uri $baseUrl
+     * @param Slim\Http\Uri $baseUrl
      * @return void
      */
     public function setBaseUrl($baseUrl)
     {
-        $this->uri = $baseUrl;
+        $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * Remove index.php from baseUrl
+     *
+     * @param string $baseUrl Getting base URL
+     * @return string Filtered base url
+     */
+    public function filterBaseUrl($baseUrl)
+    {
+        return rtrim(str_ireplace('index.php', '', $baseUrl), '/');
     }
 }


### PR DESCRIPTION
I try to use Twig-View, but unfortunelly is_current_path() is not working for me. I started investigating a problem and i want to offer some changes for this great component.

I will comment changes, that i made. I propose some things:
- to move the cleaning of $basePath from main script inside to Twig-View extention and name it filterBaseUrl(). Now we can reuse it if we need and we hide some logic from main script :)
- to check parameters in constructor to be secure, that we get all we need
- to make $uri variable only the instance of URI class, not string or class as it was.
- to add baseUrl var for setBaseUrl() method if we want to set our baseUrl value if we need.
- based on all these changes to change baseUrl() method.

I cannot guarantee that all will work as expected, because i don't know the reasons and appointments of some solutions, but for me all works as i expected. Hope these changes would be usefull and you also could find them helpfull too :)