### PR TITLE
Port for Slim 4 Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea
 composer.lock
+clover.xml
+coverage
 vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,25 @@ language: php
 
 dist: trusty
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+matrix:
+  include:
+    - php: 7.1
+      env: ANALYSIS='true'
+    - php: 7.2
+    - php: 7.3
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
-before_script: composer install
+before_script:
+  - composer require php-coveralls/php-coveralls:^2.1.0
+  - composer install -n
 
-script: vendor/bin/phpunit --coverage-text --configuration phpunit.xml.dist
+script:
+  - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - vendor/bin/phpunit
+  - vendor/bin/phpcs
+  - vendor/bin/phpstan analyse Slim
+
+after_success:
+  - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/php-coveralls --coverage_clover=clover.xml -v ; fi

--- a/README.md
+++ b/README.md
@@ -9,33 +9,33 @@ This is a Slim Framework view helper built on top of the Twig templating compone
 Via [Composer](https://getcomposer.org/)
 
 ```bash
-$ composer require slim/twig-view
+$ composer require slim/twig-view:3.0.0-alpha
 ```
 
-Requires Slim Framework 3 and PHP 5.5.0 or newer.
+Requires Slim Framework 4 and PHP 7.1 or newer.
 
 ## Usage
 
 ```php
-// Create Slim app
-$app = new \Slim\App();
+use DI\Container;
+use Slim\Factory\AppFactory;
+use Slim\Views\Twig;
+use Slim\Views\TwigExtension;
+use Slim\Views\TwigMiddleware;
 
-// Fetch DI Container
-$container = $app->getContainer();
+// Create Container
+$container = new Container();
+AppFactory::setContainer($container);
 
-// Register Twig View helper
-$container['view'] = function ($c) {
-    $view = new \Slim\Views\Twig('path/to/templates', [
-        'cache' => 'path/to/cache'
-    ]);
-    
-    // Instantiate and add Slim specific extension
-    $router = $c->get('router');
-    $uri = \Slim\Http\Uri::createFromEnvironment(new \Slim\Http\Environment($_SERVER));
-    $view->addExtension(new \Slim\Views\TwigExtension($router, $uri));
+// Create App
+$app = new AppFactory::create();
 
-    return $view;
-};
+// Add Twig-View Middleware
+$baseUrl = 'http://www.yourwebsite.com';
+$routeParser = $app->getRouteCollector()->getRouteParser();
+$twig = new Twig('path/to/templates', ['cache' => 'path/to/cache']);
+$twigMiddleware = new TwigMiddleware($twig, $container, $routeParser, $baseUrl);
+$app->add($twigMiddleware);
 
 // Define named route
 $app->get('/hello/{name}', function ($request, $response, $args) {
@@ -61,29 +61,34 @@ $app->run();
 
 `TwigExtension` provides these functions to your Twig templates:
 
-* `path_for()` - returns the URL for a given route.
-* `base_url()` - returns the `Uri` object's base URL.
-* `is_current_path()` - returns true is the provided route name and parameters are valid for the current path.
-* `current_path()` - renders the current path, with or without the query string.
+* `base_url()` - returns the base URL from the incoming Request object
+* `current_url()` - returns the current path, with or without the query string.
+* `is_current_url()` - returns true is the provided route name and parameters are valid for the current path.
+* `url_for()` - returns the URL for a given route. e.g.: /hello/world
+* `full_url_for()` - returns the URL for a given route. e.g.: http://www.example.com/hello/world
 
 
-You can use `path_for` to generate complete URLs to any Slim application named route and use `is_current_path` to determine if you need to mark a link as active as shown in this example Twig template:
+You can use `url_for` to generate complete URLs to any Slim application named route and use `is_current_url` to determine if you need to mark a link as active as shown in this example Twig template:
 
     {% extends "layout.html" %}
 
     {% block body %}
     <h1>User List</h1>
     <ul>
-        <li><a href="{{ path_for('profile', { 'name': 'josh' }) }}" {% if is_current_path('profile', { 'name': 'josh' }) %}class="active"{% endif %}>Josh</a></li>
-        <li><a href="{{ path_for('profile', { 'name': 'andrew' }) }}">Andrew</a></li>
+        <li><a href="{{ url_for('profile', { 'name': 'josh' }) }}" {% if is_current_url('profile', { 'name': 'josh' }) %}class="active"{% endif %}>Josh</a></li>
+        <li><a href="{{ url_for('profile', { 'name': 'andrew' }) }}">Andrew</a></li>
     </ul>
     {% endblock %}
 
 
-## Testing
+## Tests
+
+To execute the test suite, you'll need to clone the repository and install the dependencies.
 
 ```bash
-phpunit
+$ git clone https://github.com/slimphp/Twig-View
+$ composer install
+$ composer test
 ```
 
 ## Contributing
@@ -97,6 +102,7 @@ If you discover any security related issues, please email security@slimframework
 ## Credits
 
 - [Josh Lockhart](https://github.com/codeguy)
+- [Pierre Bérubé](https://github.com/l0gicgate)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ use Slim\Views\Twig;
 use Slim\Views\TwigExtension;
 use Slim\Views\TwigMiddleware;
 
+require __DIR__ . '/vendor/autoload.php';
+
 // Create Container
 $container = new Container();
 AppFactory::setContainer($container);
@@ -31,10 +33,10 @@ AppFactory::setContainer($container);
 $app = new AppFactory::create();
 
 // Add Twig-View Middleware
-$baseUrl = 'http://www.yourwebsite.com';
+$basePath = '/base-path';
 $routeParser = $app->getRouteCollector()->getRouteParser();
 $twig = new Twig('path/to/templates', ['cache' => 'path/to/cache']);
-$twigMiddleware = new TwigMiddleware($twig, $container, $routeParser, $baseUrl);
+$twigMiddleware = new TwigMiddleware($twig, $container, $routeParser, $basePath);
 $app->add($twigMiddleware);
 
 // Define named route
@@ -61,12 +63,11 @@ $app->run();
 
 `TwigExtension` provides these functions to your Twig templates:
 
-* `base_url()` - returns the base URL from the incoming Request object
-* `current_url()` - returns the current path, with or without the query string.
-* `is_current_url()` - returns true is the provided route name and parameters are valid for the current path.
 * `url_for()` - returns the URL for a given route. e.g.: /hello/world
 * `full_url_for()` - returns the URL for a given route. e.g.: http://www.example.com/hello/world
-
+* `is_current_url()` - returns true is the provided route name and parameters are valid for the current path.
+* `current_url()` - returns the current path, with or without the query string.
+* `get_uri()` - returns the `UriInterface` object from the incoming `ServerRequestInterface` object
 
 You can use `url_for` to generate complete URLs to any Slim application named route and use `is_current_url` to determine if you need to mark a link as active as shown in this example Twig template:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "slim/twig-view",
     "type": "library",
-    "description": "Slim Framework 3 view helper built on top of the Twig 2 templating component",
+    "description": "Slim Framework 4 view helper built on top of the Twig 2 templating component",
     "keywords": ["slim","framework","view","template","twig"],
     "homepage": "http://slimframework.com",
     "license": "MIT",
@@ -10,20 +10,28 @@
             "name": "Josh Lockhart",
             "email": "hello@joshlockhart.com",
             "homepage": "http://joshlockhart.com"
+        },
+        {
+            "name": "Pierre Berube",
+            "email": "pierre@lgse.com",
+            "homepage": "http://www.lgse.com"
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "twig/twig": "^1.38|^2.7",
-        "psr/http-message": "^1.0"
+        "php": "^7.1",
+        "psr/http-message": "^1.0",
+        "twig/twig": "^2.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.7",
-        "slim/slim": "^3.10"
+        "phpunit/phpunit": "^7.5",
+        "php-di/php-di": "^6.0",
+        "psr/http-factory": "^1.0",
+        "slim/slim": "^4.0.0-alpha"
     },
     "autoload": {
         "psr-4": {
-            "Slim\\Views\\": "src"
+            "Slim\\Views\\": "src",
+            "Slim\\Tests\\": "tests"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutChangesToGlobalState="true"
+         beStrictAboutOutputDuringTests="true"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
+         bootstrap="tests/bootstrap.php"
 >
     <testsuites>
-        <testsuite name="Slim Test Suite">
+        <testsuite name="Twig-View Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
 
     <filter>
-        <whitelist>
-            <directory>./src</directory>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>./src/</directory>
         </whitelist>
     </filter>
+
+    <logging>
+        <log
+            type="coverage-html"
+            target="./coverage"
+            lowUpperBound="20"
+            highLowerBound="50"
+        />
+    </logging>
 </phpunit>

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -2,36 +2,45 @@
 /**
  * Slim Framework (http://slimframework.com)
  *
- * @link      https://github.com/slimphp/Twig-View
- * @copyright Copyright (c) 2011-2015 Josh Lockhart
  * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Views;
 
+use ArrayAccess;
+use ArrayIterator;
 use Psr\Http\Message\ResponseInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+use Twig\Extension\ExtensionInterface;
+use Twig\Loader\FilesystemLoader;
+use Twig\Loader\LoaderInterface;
 
 /**
  * Twig View
  *
- * This class is a Slim Framework view helper built
- * on top of the Twig templating component. Twig is
- * a PHP component created by Fabien Potencier.
+ * This class is a Slim Framework view helper built on top of the Twig templating component.
+ * Twig is a PHP component created by Fabien Potencier.
  *
  * @link http://twig.sensiolabs.org/
  */
-class Twig implements \ArrayAccess
+class Twig implements ArrayAccess
 {
     /**
      * Twig loader
      *
-     * @var \Twig\Loader\LoaderInterface
+     * @var LoaderInterface
      */
     protected $loader;
 
     /**
      * Twig environment
      *
-     * @var \Twig\Environment
+     * @var Environment
      */
     protected $environment;
 
@@ -42,36 +51,25 @@ class Twig implements \ArrayAccess
      */
     protected $defaultVariables = [];
 
-    /********************************************************************************
-     * Constructors and service provider registration
-     *******************************************************************************/
-
     /**
-     * Create new Twig view
-     *
      * @param string|array $path     Path(s) to templates directory
      * @param array        $settings Twig environment settings
      */
     public function __construct($path, $settings = [])
     {
         $this->loader = $this->createLoader(is_string($path) ? [$path] : $path);
-        $this->environment = new \Twig\Environment($this->loader, $settings);
+        $this->environment = new Environment($this->loader, $settings);
     }
-
-    /********************************************************************************
-     * Methods
-     *******************************************************************************/
 
     /**
      * Proxy method to add an extension to the Twig environment
      *
-     * @param \Twig\Extension\ExtensionInterface $extension A single extension instance or an array of instances
+     * @param ExtensionInterface $extension A single extension instance or an array of instances
      */
-    public function addExtension(\Twig\Extension\ExtensionInterface $extension)
+    public function addExtension(ExtensionInterface $extension)
     {
         $this->environment->addExtension($extension);
     }
-
 
     /**
      * Fetch rendered template
@@ -79,13 +77,13 @@ class Twig implements \ArrayAccess
      * @param  string $template Template pathname relative to templates directory
      * @param  array  $data     Associative array of template variables
      *
-     * @throws \Twig\Error\LoaderError  When the template cannot be found
-     * @throws \Twig_Error\SyntaxError  When an error occurred during compilation
-     * @throws \Twig_Error\RuntimeError When an error occurred during rendering
+     * @throws LoaderError  When the template cannot be found
+     * @throws SyntaxError  When an error occurred during compilation
+     * @throws RuntimeError When an error occurred during rendering
      *
      * @return string
      */
-    public function fetch($template, $data = [])
+    public function fetch(string $template, array $data = [])
     {
         $data = array_merge($this->defaultVariables, $data);
 
@@ -101,7 +99,7 @@ class Twig implements \ArrayAccess
      *
      * @return string
      */
-    public function fetchBlock($template, $block, $data = [])
+    public function fetchBlock(string $template, string $block, array $data = [])
     {
         $data = array_merge($this->defaultVariables, $data);
 
@@ -116,7 +114,7 @@ class Twig implements \ArrayAccess
      *
      * @return string
      */
-    public function fetchFromString($string ="", $data = [])
+    public function fetchFromString(string $string = '', array $data = [])
     {
         $data = array_merge($this->defaultVariables, $data);
 
@@ -126,12 +124,12 @@ class Twig implements \ArrayAccess
     /**
      * Output rendered template
      *
-     * @param ResponseInterface $response
-     * @param  string $template Template pathname relative to templates directory
-     * @param  array $data Associative array of template variables
+     * @param  ResponseInterface $response
+     * @param  string            $template Template pathname relative to templates directory
+     * @param  array             $data Associative array of template variables
      * @return ResponseInterface
      */
-    public function render(ResponseInterface $response, $template, $data = [])
+    public function render(ResponseInterface $response, string $template, array $data = [])
     {
          $response->getBody()->write($this->fetch($template, $data));
 
@@ -142,11 +140,11 @@ class Twig implements \ArrayAccess
      * Create a loader with the given path
      *
      * @param array $paths
-     * @return \Twig\Loader\FilesystemLoader
+     * @return FilesystemLoader
      */
     private function createLoader(array $paths)
     {
-        $loader = new \Twig\Loader\FilesystemLoader();
+        $loader = new FilesystemLoader();
 
         foreach ($paths as $namespace => $path) {
             if (is_string($namespace)) {
@@ -159,16 +157,12 @@ class Twig implements \ArrayAccess
         return $loader;
     }
 
-    /********************************************************************************
-     * Accessors
-     *******************************************************************************/
-
     /**
      * Return Twig loader
      *
-     * @return \Twig\Loader\LoaderInterface
+     * @return LoaderInterface
      */
-    public function getLoader()
+    public function getLoader(): LoaderInterface
     {
         return $this->loader;
     }
@@ -176,16 +170,12 @@ class Twig implements \ArrayAccess
     /**
      * Return Twig environment
      *
-     * @return \Twig\Environment
+     * @return Environment
      */
-    public function getEnvironment()
+    public function getEnvironment(): Environment
     {
         return $this->environment;
     }
-
-    /********************************************************************************
-     * ArrayAccess interface
-     *******************************************************************************/
 
     /**
      * Does this collection have a given key?
@@ -232,10 +222,6 @@ class Twig implements \ArrayAccess
         unset($this->defaultVariables[$key]);
     }
 
-    /********************************************************************************
-     * Countable interface
-     *******************************************************************************/
-
     /**
      * Get number of items in collection
      *
@@ -246,17 +232,13 @@ class Twig implements \ArrayAccess
         return count($this->defaultVariables);
     }
 
-    /********************************************************************************
-     * IteratorAggregate interface
-     *******************************************************************************/
-
     /**
      * Get collection iterator
      *
-     * @return \ArrayIterator
+     * @return ArrayIterator
      */
     public function getIterator()
     {
-        return new \ArrayIterator($this->defaultVariables);
+        return new ArrayIterator($this->defaultVariables);
     }
 }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -59,9 +59,9 @@ class TwigExtension extends AbstractExtension
         return [
             new TwigFunction('url_for', [$this, 'urlFor']),
             new TwigFunction('full_url_for', [$this, 'fullUrlFor']),
-            new TwigFunction('base_url', [$this, 'getBaseUrl']),
             new TwigFunction('is_current_url', [$this, 'isCurrentUrl']),
             new TwigFunction('current_url', [$this, 'getCurrentUrl']),
+            new TwigFunction('get_uri', [$this, 'getUri']),
         ];
     }
 
@@ -156,7 +156,7 @@ class TwigExtension extends AbstractExtension
      *
      * @return self
      */
-    public function setBasePath($basePath): self
+    public function setBasePath(string $basePath): self
     {
         $this->basePath = $basePath;
         return $this;

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -2,126 +2,163 @@
 /**
  * Slim Framework (http://slimframework.com)
  *
- * @link      https://github.com/slimphp/Twig-View
- * @copyright Copyright (c) 2011-2015 Josh Lockhart
  * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Views;
 
-use Slim\Http\Uri;
+use Psr\Http\Message\UriInterface;
+use Slim\Interfaces\RouteParserInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class TwigExtension extends \Twig\Extension\AbstractExtension
+class TwigExtension extends AbstractExtension
 {
     /**
-     * @var \Slim\Interfaces\RouterInterface
+     * @var RouteParserInterface
      */
-    private $router;
+    protected $routeParser;
 
     /**
-     * @var string|\Slim\Http\Uri
+     * @var string
      */
-    private $uri;
+    protected $basePath = '';
 
-    public function __construct($router, $uri)
+    /**
+     * @var UriInterface
+     */
+    protected $uri;
+
+    /**
+     * @param RouteParserInterface $routeParser
+     * @param UriInterface         $uri
+     * @param string               $basePath
+     */
+    public function __construct(RouteParserInterface $routeParser, UriInterface $uri, string $basePath = '')
     {
-        $this->router = $router;
+        $this->routeParser = $routeParser;
         $this->uri = $uri;
+        $this->basePath = $basePath;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'slim';
     }
 
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions()
     {
         return [
-            new \Twig\TwigFunction('path_for', array($this, 'pathFor')),
-            new \Twig\TwigFunction('full_url_for', array($this, 'fullUrlFor')),
-            new \Twig\TwigFunction('base_url', array($this, 'baseUrl')),
-            new \Twig\TwigFunction('is_current_path', array($this, 'isCurrentPath')),
-            new \Twig\TwigFunction('current_path', array($this, 'currentPath')),
+            new TwigFunction('url_for', [$this, 'urlFor']),
+            new TwigFunction('full_url_for', [$this, 'fullUrlFor']),
+            new TwigFunction('base_url', [$this, 'getBaseUrl']),
+            new TwigFunction('is_current_url', [$this, 'isCurrentUrl']),
+            new TwigFunction('current_url', [$this, 'getCurrentUrl']),
         ];
     }
 
-    public function pathFor($name, $data = [], $queryParams = [], $appName = 'default')
+    /**
+     * @param string $routeName
+     * @param array  $data
+     * @param array  $queryParams
+     *
+     * @return string
+     */
+    public function urlFor(string $routeName, array $data = [], $queryParams = [])
     {
-        return $this->router->pathFor($name, $data, $queryParams);
+        return $this->routeParser->urlFor($routeName, $data, $queryParams);
     }
 
     /**
-     * Similar to pathFor but returns a fully qualified URL
+     * @param string $routeName   Route placeholders
+     * @param array  $data        Route placeholders
+     * @param array  $queryParams
      *
-     * @param string $name The name of the route
-     * @param array $data Route placeholders
-     * @param array $queryParams
-     * @param string $appName
-     * @return string fully qualified URL
+     * @return string
      */
-    public function fullUrlFor($name, $data = [], $queryParams = [], $appName = 'default')
+    public function fullUrlFor(string $routeName, array $data = [], array $queryParams = [])
     {
-        $path = $this->pathFor($name, $data, $queryParams, $appName);
-
-        /** @var Uri $uri */
-        if (is_string($this->uri)) {
-            $uri = Uri::createFromString($this->uri);
-        } else {
-            $uri = $this->uri;
-        }
-
-        $scheme = $uri->getScheme();
-        $authority = $uri->getAuthority();
-
-        $host = ($scheme ? $scheme . ':' : '')
-            . ($authority ? '//' . $authority : '');
-
-        return $host.$path;
+        return $this->routeParser->fullUrlFor($this->uri, $routeName, $data, $queryParams);
     }
 
-    public function baseUrl()
+    /**
+     * @param string $routeName
+     * @param array  $data
+     *
+     * @return bool
+     */
+    public function isCurrentUrl(string $routeName, $data = []): bool
     {
-        if (is_string($this->uri)) {
-            return $this->uri;
-        }
-        if (method_exists($this->uri, 'getBaseUrl')) {
-            return $this->uri->getBaseUrl();
-        }
-    }
+        $currentUrl = $this->basePath . $this->uri->getPath();
+        $result = $this->routeParser->urlFor($routeName, $data) ;
 
-    public function isCurrentPath($name, $data = [])
-    {
-        return $this->router->pathFor($name, $data) === $this->uri->getBasePath() . '/' . ltrim($this->uri->getPath(), '/');
+        return $result === $currentUrl;
     }
 
     /**
      * Returns current path on given URI.
      *
      * @param bool $withQueryString
+     *
      * @return string
      */
-    public function currentPath($withQueryString = false)
+    public function getCurrentUrl($withQueryString = false)
     {
-        if (is_string($this->uri)) {
-            return $this->uri;
+        $currentUrl = $this->basePath . $this->uri->getPath();
+        $query = $this->uri->getQuery();
+
+        if ($withQueryString && !empty($query)) {
+            $currentUrl .= '?' . $query;
         }
 
-        $path = $this->uri->getBasePath() . '/' . ltrim($this->uri->getPath(), '/');
+        return $currentUrl;
+    }
 
-        if ($withQueryString && '' !== $query = $this->uri->getQuery()) {
-            $path .= '?' . $query;
-        }
+    /**
+     * @return UriInterface
+     */
+    public function getUri(): UriInterface
+    {
+        return $this->uri;
+    }
 
-        return $path;
+    /**
+     * @param UriInterface $uri
+     *
+     * @return self
+     */
+    public function setUri(UriInterface $uri): self
+    {
+        $this->uri = $uri;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBasePath(): string
+    {
+        return $this->basePath;
     }
 
     /**
      * Set the base url
      *
-     * @param string|Slim\Http\Uri $baseUrl
-     * @return void
+     * @param string $basePath
+     *
+     * @return self
      */
-    public function setBaseUrl($baseUrl)
+    public function setBasePath($basePath): self
     {
-        $this->uri = $baseUrl;
+        $this->basePath = $basePath;
+        return $this;
     }
 }

--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Views;
+
+use ArrayAccess;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Interfaces\RouteParserInterface;
+
+class TwigMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var Twig
+     */
+    protected $twig;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var RouteParserInterface
+     */
+    protected $routeParser;
+
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * @param Twig                 $twig
+     * @param ContainerInterface   $container
+     * @param RouteParserInterface $routeParser
+     * @param string               $basePath
+     */
+    public function __construct(Twig $twig, ContainerInterface $container, RouteParserInterface $routeParser, string $basePath = '')
+    {
+        $this->twig = $twig;
+        $this->container = $container;
+        $this->routeParser = $routeParser;
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $extension = new TwigExtension($this->routeParser, $request->getUri(), $this->basePath);
+        $this->twig->addExtension($extension);
+
+        if (method_exists($this->container, 'set')) {
+            $this->container->set('view', $this->twig);
+        } elseif ($this->container instanceof ArrayAccess) {
+            $this->container['view'] = $this->twig;
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/Mocks/MockContainerWithArrayAccess.php
+++ b/tests/Mocks/MockContainerWithArrayAccess.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use ArrayAccess;
+use Psr\Container\ContainerInterface;
+
+class MockContainerWithArrayAccess implements ArrayAccess, ContainerInterface
+{
+    /**
+     * @var array
+     */
+    private $data = [];
+
+    public function get($id)
+    {
+        return $this->has($id) ? $this->data[$id] : null;
+    }
+
+    public function has($id)
+    {
+        return isset($this->data[$id]);
+    }
+
+    public function offsetExists($offset)
+    {
+        return $this->has($offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests;
+
+use PHPUnit\Framework\TestCase as PhpUnitTestCase;
+
+abstract class TestCase extends PhpUnitTestCase
+{
+}

--- a/tests/TwigMiddlewareTest.php
+++ b/tests/TwigMiddlewareTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests;
+
+use DI\Container;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Interfaces\RouteParserInterface;
+use Slim\Tests\Mocks\MockContainerWithArrayAccess;
+use Slim\Views\Twig;
+use Slim\Views\TwigExtension;
+use Slim\Views\TwigMiddleware;
+
+class TwigMiddlewareTest extends TestCase
+{
+    public function testProcessAppendsTwigExtensionToContainerWithSetMethod()
+    {
+        $self = $this;
+
+        $basePath = '/base-path';
+        $uriProphecy = $this->prophesize(UriInterface::class);
+
+        $twigProphecy = $this->prophesize(Twig::class);
+        $twigProphecy
+            ->addExtension(Argument::type('object'))
+            ->will(function ($args) use ($self, $uriProphecy, $basePath) {
+                /** @var TwigExtension $extension */
+                $extension = $args[0];
+
+                $self->assertEquals($uriProphecy->reveal(), $extension->getUri());
+                $self->assertEquals($basePath, $extension->getBasePath());
+            })
+            ->shouldBeCalledOnce();
+
+        $routeParserProphecy = $this->prophesize(RouteParserInterface::class);
+        $container = new Container();
+
+        $twigMiddleware = new TwigMiddleware(
+            $twigProphecy->reveal(),
+            $container,
+            $routeParserProphecy->reveal(),
+            $basePath
+        );
+
+        $responseProphecy = $this->prophesize(ResponseInterface::class);
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy
+            ->getUri()
+            ->willReturn($uriProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $requestHandlerProphecy = $this->prophesize(RequestHandlerInterface::class);
+        $requestHandlerProphecy
+            ->handle($requestProphecy->reveal())
+            ->shouldBeCalledOnce()
+            ->willReturn($responseProphecy->reveal());
+
+        $twigMiddleware->process($requestProphecy->reveal(), $requestHandlerProphecy->reveal());
+
+        $this->assertSame($twigProphecy->reveal(), $container->get('view'));
+    }
+
+    public function testProcessAppendsTwigExtensionToContainerWithArrayAccess()
+    {
+        $self = $this;
+
+        $basePath = '/base-path';
+        $uriProphecy = $this->prophesize(UriInterface::class);
+
+        $twigProphecy = $this->prophesize(Twig::class);
+        $twigProphecy
+            ->addExtension(Argument::type('object'))
+            ->will(function ($args) use ($self, $uriProphecy, $basePath) {
+                /** @var TwigExtension $extension */
+                $extension = $args[0];
+
+                $self->assertEquals($uriProphecy->reveal(), $extension->getUri());
+                $self->assertEquals($basePath, $extension->getBasePath());
+            })
+            ->shouldBeCalledOnce();
+
+        $routeParserProphecy = $this->prophesize(RouteParserInterface::class);
+        $container = new MockContainerWithArrayAccess();
+
+        $twigMiddleware = new TwigMiddleware(
+            $twigProphecy->reveal(),
+            $container,
+            $routeParserProphecy->reveal(),
+            $basePath
+        );
+
+        $responseProphecy = $this->prophesize(ResponseInterface::class);
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy
+            ->getUri()
+            ->willReturn($uriProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $requestHandlerProphecy = $this->prophesize(RequestHandlerInterface::class);
+        $requestHandlerProphecy
+            ->handle($requestProphecy->reveal())
+            ->shouldBeCalledOnce()
+            ->willReturn($responseProphecy->reveal());
+
+        $twigMiddleware->process($requestProphecy->reveal(), $requestHandlerProphecy->reveal());
+
+        $this->assertSame($twigProphecy->reveal(), $container->get('view'));
+    }
+}

--- a/tests/TwigTest.php
+++ b/tests/TwigTest.php
@@ -2,17 +2,18 @@
 /**
  * Slim Framework (http://slimframework.com)
  *
- * @link      https://github.com/codeguy/Slim
- * @copyright Copyright (c) 2011-2015 Josh Lockhart
- * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
  */
-namespace Slim\Tests\Views;
 
+declare(strict_types=1);
+
+namespace Slim\Tests;
+
+use DateTimeImmutable;
+use Psr\Http\Message\ResponseInterface;
 use Slim\Views\Twig;
 
-require dirname(__DIR__) . '/vendor/autoload.php';
-
-class TwigTest extends \PHPUnit_Framework_TestCase
+class TwigTest extends TestCase
 {
     public function testFetch()
     {
@@ -54,7 +55,7 @@ class TwigTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleNamespaceAndMultipleDirectories()
     {
-        $weekday = (new \DateTimeImmutable('2016-03-08'))->format('l');
+        $weekday = (new DateTimeImmutable('2016-03-08'))->format('l');
 
         $view = new Twig(
             [
@@ -114,7 +115,7 @@ class TwigTest extends \PHPUnit_Framework_TestCase
 
     public function testMultipleTemplatesWithMultipleNamespace()
     {
-        $weekday = (new \DateTimeImmutable('2016-03-08'))->format('l');
+        $weekday = (new DateTimeImmutable('2016-03-08'))->format('l');
 
         $views = new Twig([
             'One'   => __DIR__.'/templates',
@@ -144,7 +145,7 @@ class TwigTest extends \PHPUnit_Framework_TestCase
 
     public function testMultipleDirectoriesWithoutNamespaces()
     {
-        $weekday = (new \DateTimeImmutable('2016-03-08'))->format('l');
+        $weekday = (new DateTimeImmutable('2016-03-08'))->format('l');
         $view    = new Twig([__DIR__.'/multi/', __DIR__.'/another/']);
 
         $rootDirectory = $view->fetch('directory/template/example.html', [
@@ -183,6 +184,6 @@ class TwigTest extends \PHPUnit_Framework_TestCase
         $response = $view->render($mockResponse, 'example.html', [
             'name' => 'Josh'
         ]);
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This is a port of Twig-View for usage with the new Slim 4 interfaces which requires a major release.

The `Twig` object's API remains the same. The `TwigExtension` interface has changed to reflect the new naming convention from Slim 4's `RouteParser`:

**The new public interface for TwigExtension**:
- `TwigExtension::urlFor()` - Formerly `pathFor()`
- `TwigExtension::fullUrlFor()` - Stays the same
- `TwigExtension::isCurrentUrl()` - Formerly `isCurrentPath()`
- `TwigExtension::getCurrentUrl()` - Formerly `currentPath()`
- `TwigExtension::getBasePath()`
- `TwigExtension::setBasePath()` 
- `TwigExtension::getUri()` - Formerly `baseUrl()`
- `TwigExtension:setUri()`

**Example usage with PHP-DI**
```php
use DI\Container;
use Slim\Factory\AppFactory;
use Slim\Views\Twig;
use Slim\Views\TwigExtension;
use Slim\Views\TwigMiddleware;

require __DIR__ . '/vendor/autoload.php';

// Create Container
$container = new Container();
AppFactory::setContainer($container);

// Create App
$app = new AppFactory::create();

// Add Twig-View Middleware
$basePath = '/base-path';
$routeParser = $app->getRouteCollector()->getRouteParser();
$twig = new Twig('path/to/templates', ['cache' => 'path/to/cache']);
$twigMiddleware = new TwigMiddleware($twig, $container, $routeParser, $basePath);
$app->add($twigMiddleware);

// Define named route
$app->get('/hello/{name}', function ($request, $response, $args) {
    return $this->view->render($response, 'profile.html', [
        'name' => $args['name']
    ]);
})->setName('profile');

// Render from string
$app->get('/hi/{name}', function ($request, $response, $args) {
    $str = $this->view->fetchFromString('<p>Hi, my name is {{ name }}.</p>', [
        'name' => $args['name']
    ]);
    $response->getBody()->write($str);
    return $response;
});

// Run app
$app->run();
```
