### PR TITLE
[WIP] [3.x] Add middleware self-factory

### DIFF
--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -15,6 +15,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use Slim\App;
 use Slim\Interfaces\RouteParserInterface;
 
 class TwigMiddleware implements MiddlewareInterface
@@ -43,6 +45,32 @@ class TwigMiddleware implements MiddlewareInterface
      * @var string
      */
     protected $containerKey;
+
+    /**
+     * @param App    $app
+     * @param string $containerKey
+     *
+     * @return TwigMiddleware
+     */
+    public static function create(App $app, string $containerKey = 'view'): self
+    {
+        if ($app->getContainer() === null) {
+            throw new RuntimeException('The app does not have a container.');
+        }
+
+        $twig = $app->getContainer()->get($containerKey);
+        if (!($twig instanceof Twig)) {
+            throw new RuntimeException(sprintf('Twig could not be found in the container (key=%s).', $containerKey));
+        }
+
+        return new self(
+            $twig,
+            $app->getContainer(),
+            $app->getRouteCollector()->getRouteParser(),
+            $app->getBasePath(),
+            $containerKey
+        );
+    }
 
     /**
      * @param Twig                 $twig


### PR DESCRIPTION
This PR addresses #118.

Remember that if a user would like to use this self-factory, he/she needs to add `Twig` to the container before calling the method.

The problem is, that in the `process()`-method `Twig` would be added again to the container. Should we check and avoid that?