### PR TITLE
3.x - Add `TwigContext` to pass twig via server request attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $container->set('view', function() {
 $app = new AppFactory::create();
 
 // Add Twig-View Middleware
-$app->add(TwigMiddleware::create($app));
+$app->add(TwigMiddleware::createFromContainer($app));
 
 // Define named route
 $app->get('/hello/{name}', function ($request, $response, $args) {

--- a/src/TwigContext.php
+++ b/src/TwigContext.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Views;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+
+class TwigContext
+{
+    /**
+     * @param ServerRequestInterface $serverRequest
+     * @param string                 $attributeName
+     *
+     * @return Twig
+     */
+    public static function fromRequest(ServerRequestInterface $serverRequest, string $attributeName = 'view'): Twig
+    {
+        $twig = $serverRequest->getAttribute($attributeName);
+        if ($twig === null) {
+            throw new RuntimeException(sprintf(
+                'Twig could not be found in the server request attributes using the key "%s".',
+                $attributeName
+            ));
+        }
+
+        return $twig;
+    }
+}

--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -36,6 +36,11 @@ class TwigMiddleware implements MiddlewareInterface
     protected $basePath;
 
     /**
+     * @var string|null
+     */
+    protected $serverRequestAttributeName;
+
+    /**
      * @param App    $app
      * @param string $containerKey
      *
@@ -71,15 +76,18 @@ class TwigMiddleware implements MiddlewareInterface
      * @param Twig                 $twig
      * @param RouteParserInterface $routeParser
      * @param string               $basePath
+     * @param string|null          $serverRequestAttributeName
      */
     public function __construct(
         Twig $twig,
         RouteParserInterface $routeParser,
-        string $basePath = ''
+        string $basePath = '',
+        ?string $serverRequestAttributeName = null
     ) {
         $this->twig = $twig;
         $this->routeParser = $routeParser;
         $this->basePath = $basePath;
+        $this->serverRequestAttributeName = $serverRequestAttributeName;
     }
 
     /**
@@ -92,6 +100,10 @@ class TwigMiddleware implements MiddlewareInterface
 
         $extension = new TwigExtension();
         $this->twig->addExtension($extension);
+
+        if ($this->serverRequestAttributeName !== null) {
+            $request = $request->withAttribute($this->serverRequestAttributeName, $this->twig);
+        }
 
         return $handler->handle($request);
     }

--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -46,7 +46,7 @@ class TwigMiddleware implements MiddlewareInterface
      *
      * @return TwigMiddleware
      */
-    public static function create(App $app, string $containerKey = 'view'): self
+    public static function createFromContainer(App $app, string $containerKey = 'view'): self
     {
         $container = $app->getContainer();
         if ($container === null) {

--- a/tests/TwigContextTest.php
+++ b/tests/TwigContextTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @license   https://github.com/slimphp/Twig-View/blob/master/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Slim\Views\Twig;
+use Slim\Views\TwigContext;
+
+class TwigContextTest extends TestCase
+{
+    public function testFromRequest()
+    {
+        $twig = $this->createMock(Twig::class);
+
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $serverRequestProphecy->getAttribute('view')
+            ->willReturn($twig);
+
+        /** @var ServerRequestInterface $serverRequest */
+        $serverRequest = $serverRequestProphecy->reveal();
+        $this->assertSame($twig, TwigContext::fromRequest($serverRequest));
+    }
+
+    public function testFromRequestCustomAttributeName()
+    {
+        $twig = $this->createMock(Twig::class);
+
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $serverRequestProphecy->getAttribute('foo')
+            ->willReturn($twig);
+
+        /** @var ServerRequestInterface $serverRequest */
+        $serverRequest = $serverRequestProphecy->reveal();
+        $this->assertSame($twig, TwigContext::fromRequest($serverRequest, 'foo'));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Twig could not be found in the server request attributes using the key "view".
+     */
+    public function testFromRequestTwigNotFound()
+    {
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $serverRequestProphecy->getAttribute('view')
+            ->willReturn(null);
+
+        /** @var ServerRequestInterface $serverRequest */
+        $serverRequest = $serverRequestProphecy->reveal();
+        TwigContext::fromRequest($serverRequest);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Twig could not be found in the server request attributes using the key "foo".
+     */
+    public function testFromRequestCustomAttributeNameTwigNotFound()
+    {
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $serverRequestProphecy->getAttribute('foo')
+            ->willReturn(null);
+
+        /** @var ServerRequestInterface $serverRequest */
+        $serverRequest = $serverRequestProphecy->reveal();
+        TwigContext::fromRequest($serverRequest, 'foo');
+    }
+}

--- a/tests/TwigMiddlewareTest.php
+++ b/tests/TwigMiddlewareTest.php
@@ -96,7 +96,7 @@ class TwigMiddlewareTest extends TestCase
         $app->method('getRouteCollector')->willReturn($routeCollector);
         $app->method('getBasePath')->willReturn($basePath);
 
-        $middleware = TwigMiddleware::create($app, $key);
+        $middleware = TwigMiddleware::createFromContainer($app, $key);
 
         $this->assertInaccessiblePropertySame($twig, $middleware, 'twig');
         $this->assertInaccessiblePropertySame($routeParser, $middleware, 'routeParser');
@@ -110,7 +110,7 @@ class TwigMiddlewareTest extends TestCase
     public function testCreateWithoutContainer()
     {
         $app = $this->createMock(App::class);
-        TwigMiddleware::create($app);
+        TwigMiddleware::createFromContainer($app);
     }
 
     /**
@@ -128,7 +128,7 @@ class TwigMiddlewareTest extends TestCase
         $app = $this->createMock(App::class);
         $app->method('getContainer')->willReturn($container);
 
-        TwigMiddleware::create($app);
+        TwigMiddleware::createFromContainer($app);
     }
 
     /**
@@ -150,7 +150,7 @@ class TwigMiddlewareTest extends TestCase
         $app = $this->createMock(App::class);
         $app->method('getContainer')->willReturn($container);
 
-        TwigMiddleware::create($app);
+        TwigMiddleware::createFromContainer($app);
     }
 
     public function testProcess()


### PR DESCRIPTION
This PR is a solution for #124. It enhances the `TwigMiddleware` such that it can be used without any DI-container.

## Usage
By passing the fourth parameter to the constructor, the middleware would automatically add twig to the server request when processed. Then, in a route callback, twig can be get using the `TwigContext` helper class.
```php
// ...

$twig = new Twig(__DIR__ . '/../templates');
$app->add(
    new TwigMiddleware($twig, $app->getRouteCollector()->getRouteParser(), $app->getBasePath(), 'view')
);

// ...

$app->get('/', function (Request $request, Response $response, $args): Response {
    // Get twig from the server request.
    $twig = \Slim\Views\TwigContext::fromRequest($request);
    $twig->render($response, 'index.twig');

    return $response;
});

// ...
```