### PR TITLE
Fix Twig instantiation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ AppFactory::setContainer($container);
 
 // Set view in Container
 $container->set('view', function() {
-    return Twig::create('path/to/templates', ['cache' => 'path/to/cache']);
+    return new Twig('path/to/templates', ['cache' => 'path/to/cache']);
 });
 
 // Create App


### PR DESCRIPTION
The static method `Twig::create` does not exists. 
This fix will update the Twig instantiation example.