### PR TITLE
Fix url to Twig

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -30,7 +30,7 @@ use Twig\RuntimeLoader\RuntimeLoaderInterface;
  * This class is a Slim Framework view helper built on top of the Twig templating component.
  * Twig is a PHP component created by Fabien Potencier.
  *
- * @link http://twig.sensiolabs.org/
+ * @link https://twig.symfony.com/
  */
 class Twig implements ArrayAccess
 {


### PR DESCRIPTION
This PR simply updates the url to the Twig website which is at https://twig.symfony.com/