### PR TITLE
[3.x] Fix access to undefined array index

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -245,6 +245,9 @@ class Twig implements ArrayAccess
      */
     public function offsetGet($key)
     {
+        if (!$this->offsetExists($key)) {
+            return null;
+        }
         return $this->defaultVariables[$key];
     }
 

--- a/tests/TwigTest.php
+++ b/tests/TwigTest.php
@@ -332,6 +332,13 @@ EOF
         $this->assertEquals('bar', $view->offsetGet('foo'));
     }
 
+    public function testOffsetGetUndefined()
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $view = new Twig($loader);
+        $this->assertNull($view->offsetGet('foo'));
+    }
+
     public function testOffsetUnset()
     {
         $loader = $this->createMock(LoaderInterface::class);


### PR DESCRIPTION
This fixes a possible notice if the array index in `\Slim\Views\Twig::$defaultVariables` does not exist.