### PR TITLE
Support Installing Twig 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "twig/twig": "^1.38|^2.7",
+        "twig/twig": "^1.38|^2.7|^3.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -105,7 +105,7 @@ class Twig implements \ArrayAccess
     {
         $data = array_merge($this->defaultVariables, $data);
 
-        return $this->environment->loadTemplate($template)->renderBlock($block, $data);
+        return $this->environment->load($template)->renderBlock($block, $data);
     }
 
     /**


### PR DESCRIPTION
Allows package consumers to install Twig 3. Also replaces a call to an `@internal` Twig method which has [different arguments in Twig 3](https://github.com/twigphp/Twig/commit/653dddd1f962e5cf6818f11e8757c82becd35a4f#diff-2604a7b7168c0a191cd22408d907dd44L379-R379) with a public method. All tests pass with Twig 1.42.4, 2.12.2 and 3.0.0 (the latest versions permitted by the Composer constraints).

_Closes #156_