### PR TITLE
Replace HHVM with PHP 7.2 & 7.3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
+  - 7.3
 
 before_script: composer install
 


### PR DESCRIPTION
Replaces testing on HHVM (which as of February ["no longer aims to be compatible with PHP"](https://hhvm.com/blog/2019/02/11/hhvm-4.0.0.html)) with PHP 7.2 and 7.3.