### PR TITLE
Update the render method in the Twig class

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ $app->get('/hi/{name}', function ($request, $response, $args) {
 // Run app
 $app->run();
 ```
+## Two ways to use the render() method
+
+The first:
+```php
+$view->render($response, 'example.html', ['name' => 'Josh'])
+````
+The second requires you to set any implementation of the PSR-17 response factory otherwise an exception will be thrown:
+```php
+$view->setResponseFactory($someResponseFactory);
+
+$view->render('example.html', ['name' => 'Josh'])
+```
 
 ## Custom template functions
 

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "psr/http-message": "^1.0",
+        "psr/http-factory": "^1.0",
         "slim/slim": "^4.9",
-        "twig/twig": "^3.3"
+        "twig/twig": "^3.3",
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3.8",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^0.12.99",
-        "psr/http-factory": "^1.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {


### PR DESCRIPTION
I remind that the Slim allows to define a custom route invocation strategy that determines arguments coming into the callable request handler (see [Slim's docs](https://www.slimframework.com/docs/v4/objects/routing.html#route-strategies)).

And current implementation of the `render()` method assumes that the handler's arugments will necessarily contain the `ResponseInterface` object. But I, for example, use my own rout strategy that allows to omit unnecessary arguments, including the `ResponseInterface` object.

So I offer to make the `render()` method flexible - so that the user can choose the most convenient form of the method:
```php
$view->render($response, 'example.html', ['name' => 'Josh'])

// OR

$view->render('example.html', ['name' => 'Josh'])
```

i.e. the `$response` may or may not be among the arguments of the method.

### What was done:

**1\)** Moving `psr/http-factory` from the `require-dev` section to the `require` (for having `ResponseFactoryInterface` in the `Twig` class) in the `composer.json`

**2\)** Updating the `render` method (including the doc block)

**3\)** Adding the `$responseFactory` protected property and `setResponseFactory` method (we can't inject a response factory to/in the constructor because `ResponseFactoryInterface` assumes different PSR-17 implementatons used by users)

**4\)** The `testRender()` method was split into two methods: `testRenderWithResponseFactory()` and `testRenderWithoutResponseFactory()`. The code that initializes a `$view`, `$mockBody`, `$mockResponse`, `$mockResponseFactory` for the two test methods was put in a separate auxiliary method.

**5\)** Adding the `testInvalidArgumentInRender()` and `testNotDefinedResponseFactoryInRender()` test methods.

**6\)** Removing 2 unused class imports in 'use' section (`Twig\Loader\FilesystemLoader` and `Slim\Views\TwigContext`) in `TwigTest`

**7\)** Replacing deprecated `setMethods()` with `onlyMethods()` (https://github.com/sebastianbergmann/phpunit/pull/3687 and https://github.com/sebastianbergmann/phpunit/issues/3769) in `testAddRuntimeLoader()`

**8\)** Updating README.md