### PR TITLE
Drop Support for PHP 7.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,17 +6,10 @@ jobs:
     tests:
         name: Tests PHP ${{ matrix.php }}
         runs-on: ubuntu-latest
-        continue-on-error: ${{ matrix.experimental }}
         strategy:
             fail-fast: false
             matrix:
-                php: [7.3, 7.4, 8.0]
-                experimental: [false]
-                include:
-                    - php: 8.0
-                      analysis: true
-                    - php: 8.1
-                      experimental: true
+                php: [7.4, 8.0, 8.1]
 
         steps:
             - name: Checkout

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Via [Composer](https://getcomposer.org/)
 $ composer require slim/twig-view:^3.0
 ```
 
-Requires Slim Framework 4, Twig 3 and PHP 7.3 or newer.
+Requires Slim Framework 4, Twig 3 and PHP 7.4 or newer.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "psr/http-message": "^1.0",
         "slim/slim": "^4.9",
         "twig/twig": "^3.3",

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -46,24 +46,20 @@ class Twig implements ArrayAccess
 {
     /**
      * Twig loader
-     *
-     * @var LoaderInterface
      */
-    protected $loader;
+    protected LoaderInterface $loader;
 
     /**
      * Twig environment
-     *
-     * @var Environment
      */
-    protected $environment;
+    protected Environment $environment;
 
     /**
      * Default view variables
      *
      * @var array<string, mixed>
      */
-    protected $defaultVariables = [];
+    protected array $defaultVariables = [];
 
     /**
      * @param ServerRequestInterface $request

--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -20,25 +20,13 @@ use Slim\Interfaces\RouteParserInterface;
 
 class TwigMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var Twig
-     */
-    protected $twig;
+    protected Twig $twig;
 
-    /**
-     * @var RouteParserInterface
-     */
-    protected $routeParser;
+    protected RouteParserInterface $routeParser;
 
-    /**
-     * @var string
-     */
-    protected $basePath;
+    protected string $basePath;
 
-    /**
-     * @var string|null
-     */
-    protected $attributeName;
+    protected ?string $attributeName;
 
     /**
      * @param App    $app

--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -96,7 +96,12 @@ class TwigMiddleware implements MiddlewareInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Process an incoming server request.
+     *
+     * @param ServerRequestInterface  $request
+     * @param RequestHandlerInterface $handler
+     *
+     * @return ResponseInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/src/TwigRuntimeExtension.php
+++ b/src/TwigRuntimeExtension.php
@@ -15,20 +15,11 @@ use Slim\Interfaces\RouteParserInterface;
 
 class TwigRuntimeExtension
 {
-    /**
-     * @var RouteParserInterface
-     */
-    protected $routeParser;
+    protected RouteParserInterface $routeParser;
 
-    /**
-     * @var string
-     */
-    protected $basePath = '';
+    protected string $basePath = '';
 
-    /**
-     * @var UriInterface
-     */
-    protected $uri;
+    protected UriInterface $uri;
 
     /**
      * @param RouteParserInterface $routeParser Route parser

--- a/src/TwigRuntimeLoader.php
+++ b/src/TwigRuntimeLoader.php
@@ -37,7 +37,11 @@ class TwigRuntimeLoader implements RuntimeLoaderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Create the runtime implementation of a Twig element.
+     *
+     * @param string $class
+     *
+     * @return mixed
      */
     public function load(string $class)
     {

--- a/src/TwigRuntimeLoader.php
+++ b/src/TwigRuntimeLoader.php
@@ -16,20 +16,11 @@ use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
 class TwigRuntimeLoader implements RuntimeLoaderInterface
 {
-    /**
-     * @var RouteParserInterface
-     */
-    protected $routeParser;
+    protected RouteParserInterface $routeParser;
 
-    /**
-     * @var UriInterface
-     */
-    protected $uri;
+    protected UriInterface $uri;
 
-    /**
-     * @var string
-     */
-    protected $basePath = '';
+    protected string $basePath = '';
 
     /**
      * TwigRuntimeLoader constructor.

--- a/tests/TwigRuntimeExtensionTest.php
+++ b/tests/TwigRuntimeExtensionTest.php
@@ -66,7 +66,7 @@ class TwigRuntimeExtensionTest extends TestCase
         return $route;
     }
 
-    public function isCurrentUrlProvider()
+    public function isCurrentUrlProvider(): array
     {
         return [
             ['/hello/{name}', ['name' => 'world'], '/hello/world', '/base-path', true],
@@ -109,7 +109,7 @@ class TwigRuntimeExtensionTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function currentUrlProvider()
+    public function currentUrlProvider(): array
     {
         return [
             ['/hello/{name}', 'http://example.com/hello/world?a=b', '', true],
@@ -164,7 +164,7 @@ class TwigRuntimeExtensionTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function urlForProvider()
+    public function urlForProvider(): array
     {
         return [
             ['/hello/{name}', ['name' => 'world'], [], '', '/hello/world'],
@@ -204,7 +204,7 @@ class TwigRuntimeExtensionTest extends TestCase
         $this->assertEquals($expectedUrl, $extension->urlFor($routeName, $routeData, $queryParams));
     }
 
-    public function fullUrlForProvider()
+    public function fullUrlForProvider(): array
     {
         return [
             ['/hello/{name}', ['name' => 'world'], [], '', 'http://localhost/hello/world'],


### PR DESCRIPTION
This PR drops support for PHP 7.3 since [it reached its end of life and is no longer supported](https://www.php.net/eol.php).