### PR TITLE
Use late static bindings in factory methods

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -85,7 +85,7 @@ class Twig implements ArrayAccess
      *
      * @throws LoaderError When the template cannot be found
      *
-     * @return Twig
+     * @return static
      */
     public static function create($path, array $settings = []): self
     {
@@ -100,7 +100,7 @@ class Twig implements ArrayAccess
             }
         }
 
-        return new self($loader, $settings);
+        return new static($loader, $settings);
     }
 
     /**

--- a/src/TwigMiddleware.php
+++ b/src/TwigMiddleware.php
@@ -32,7 +32,7 @@ class TwigMiddleware implements MiddlewareInterface
      * @param App    $app
      * @param string $containerKey
      *
-     * @return TwigMiddleware
+     * @return static
      */
     public static function createFromContainer(App $app, string $containerKey = 'view'): self
     {
@@ -53,7 +53,7 @@ class TwigMiddleware implements MiddlewareInterface
             );
         }
 
-        return new self(
+        return new static(
             $twig,
             $app->getRouteCollector()->getRouteParser(),
             $app->getBasePath()
@@ -65,11 +65,11 @@ class TwigMiddleware implements MiddlewareInterface
      * @param Twig   $twig
      * @param string $attributeName
      *
-     * @return TwigMiddleware
+     * @return static
      */
     public static function create(App $app, Twig $twig, string $attributeName = 'view'): self
     {
-        return new self(
+        return new static(
             $twig,
             $app->getRouteCollector()->getRouteParser(),
             $app->getBasePath(),


### PR DESCRIPTION
Use late static bindings in factory methods to facilitate constructing derived classes.

Retained the return types for PHP <8.0 compatibility.