### PR TITLE
Fix Twig security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/http-message": "^1.1 || ^2.0",
         "slim/slim": "^4.12",
         "symfony/polyfill-php81": "^1.29",
-        "twig/twig": "^3.8"
+        "twig/twig": "^3.11"
     },
     "require-dev": {
         "phpspec/prophecy-phpunit": "^2.0",


### PR DESCRIPTION
Bump twig/twig dependency to version 3.11.1 to address a Twig security issue (CVE-2024-45411).

Issue already fixed, and further details are available at https://github.com/twigphp/Twig/security/advisories/GHSA-6j75-5wfj-gh66

## phpunit tests result

```
$ XDEBUG_MODE=coverage vendor/bin/phpunit
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

.....................................................             53 / 53 (100%)

Time: 00:00.255, Memory: 16.00 MB

OK (53 tests, 114 assertions)
```